### PR TITLE
[docs] Adds comments to vethcon.go, adds usage() function to print usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ Using `vethcon`, you can simply make point-to-point connection for containers wi
                -d <container>:<linkname>:<IPv4 addr>/<prefixlen> |
                -n <netns name>:<linkname> |
                -n <netns name>:<linkname>:<IPv4 addr>/<prefixlen> ]
+              [-h]
 
 # Usage
+
+    # Print usage instruction
+    ./vethcon -h
 
     # Config veth without IPv4 addr
     ./vethcon -d <container>:<linkname> -d <container>:<linkname>


### PR DESCRIPTION
Tomo -- I'm working on my blog article about vethcon (almost finished!) but, in the process I was going through looking at the code and made comments therein while I was there.

Also -- I added in a `usage()` function that prints out the usage either with a `-h` flag or when you make a mistake with the command line arguments (e.g. with the error handling that you have in main() that handles the command line argument parsing).

Figured I'd ship these back to you if you'd like 'em!

Hopefully finish up that blog article tomorrow.